### PR TITLE
renames package name to prevent collision with offiical package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "influx",
+  "name": "influx-tfg",
   "version": "4.0.1",
-  "description": "InfluxDB Client",
+  "description": "InfluxDB Client Internal TFG Fork",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha -R dot",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "influx-tfg",
+  "name": "tfg-influx",
   "version": "4.0.1",
-  "description": "InfluxDB Client Internal TFG Fork",
+  "description": "InfluxDB Client",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/mocha -R dot",


### PR DESCRIPTION
This will allow upstream and internal forks to be installed in the same repo, allowing us to write the actual next version of the take5 historian writer.
